### PR TITLE
Enable Batch (CMD) commands

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -23,9 +23,22 @@ class collectCommand:
 
     
     
-    def exe(self):
-        print("\033[36m" + "[INFO] Running command: '"+self.cmd+"'")
+    def exePS(self):
+        print("\033[36m" + "[INFO][PS] Running command: '"+self.cmd+"'")
         command_output = subprocess.check_output(['powershell', '-Command', self.cmd, self.format]).decode('utf-8')
+        outputlines = command_output.split("\n")
+        finaloutput = ""
+        for line in outputlines:
+            finaloutput += line
+        file_name = self.friendly + '.txt'
+        file_path = os.path.join(self.filedir, file_name)
+        with open(file_path, 'w') as file:
+            file.write(finaloutput)
+        print("\033[32m" + "[SUCCESS] Command output saved as '"+self.friendly+".txt'")
+
+    def exeCMD(self):
+        print("\033[36m" + "[INFO][CMD] Running command: '"+self.cmd+"'")
+        command_output = subprocess.check_output(self.cmd, shell=True).decode('utf-8')
         outputlines = command_output.split("\n")
         finaloutput = ""
         for line in outputlines:
@@ -75,8 +88,14 @@ for category in jsoncmd['categories']:
     os.mkdir(newcatdir)
 
     for cmd in category["cmds"]:
-        cmd = collectCommand(cmd["command"], newcatdir, cmd["friendly"], cmd["format"])
-        cmd.exe()
+        if cmd["type"] == "cmd":
+            cmd = collectCommand(cmd["command"], newcatdir, cmd["friendly"], "none")
+            cmd.exeCMD()
+        elif cmd['type'] == "ps":
+            cmd = collectCommand(cmd["command"], newcatdir, cmd["friendly"], cmd["format"])
+            cmd.exePS()
+        else:
+            print("\033[91m" + "[ERROR] No Type Specified for Command", cmd["command"])
 
 
 

--- a/config.json
+++ b/config.json
@@ -6,36 +6,43 @@
             "cmds" : [
                 {
                     "command" : "Get-CimInstance win32_processor | select Name, Manufacturer, MaxClockSpeed, NumberOfCores",
+                    "type" : "ps",
                     "friendly" : "CPU Information",
                     "format" : "list"
                 },
                 {
                     "command" : "Get-CimInstance win32_physicalmemory | select BankLabel, Manufacturer, PartNumber, SerialNumber, Capacity, Speed, FormFactor",
+                    "type" : "ps",
                     "friendly" : "RAM Information",
                     "format" : "table"
                 },
                 {
                     "command" : "Get-PhysicalDisk",
+                    "type" : "ps",
                     "friendly" : "Disk Information",
                     "format" : "list"
                 },
                 {
                     "command" : "Get-WmiObject win32_bios; Get-WmiObject win32_computersystem",
+                    "type" : "ps",
                     "friendly" : "Hardware Information",
                     "format" : "none"
                 },
                 {
                     "command" : "dsregcmd /status",
+                    "type" : "ps",
                     "friendly" : "Domain Status",
                     "format" : "none"
                 },
                 {
                     "command" : "[Environment]::GetEnvironmentVariables([EnvironmentVariableTarget]::Machine)",
+                    "type" : "ps",
                     "friendly" : "Environment Vars - System",
                     "format" : "none"
                 },
                 {
                     "command" : "[Environment]::GetEnvironmentVariables([EnvironmentVariableTarget]::User)",
+                    "type" : "ps",
                     "friendly" : "Environment Vars - User",
                     "format" : "none"
                 }
@@ -46,31 +53,37 @@
             "cmds" : [
                 {
                     "command" : "Get-NetAdapter",
+                    "type" : "ps",
                     "friendly" : "Network Adapters",
                     "format" : "list"
                 },
                 {
                     "command" : "Get-NetIPAddress",
+                    "type" : "ps",
                     "friendly" : "Network Addresses",
                     "format" : "none"
                 },
                 {
                     "command" : "ipconfig /all",
+                    "type" : "ps",
                     "friendly" : "IP Config",
                     "format" : "none"
                 },
                 {
                     "command" : "route print",
+                    "type" : "ps",
                     "friendly" : "Routing Table",
                     "format" : "none"
                 },
                 {
                     "command" : "Test-Connection 8.8.8.8",
+                    "type" : "ps",
                     "friendly" : "Connection Test - Google DNS",
                     "format" : "none"
                 },
                 {
                     "command" : "$ProgressPreference = 'SilentlyContinue'; Test-NetConnection -ComputerName (Get-NetRoute | Where-Object DestinationPrefix -eq '0.0.0.0/0' | Select-Object -First 1).NextHop",
+                    "type" : "ps",
                     "friendly" : "Connection Test - Default Gateway",
                     "format" : "none"
                 }
@@ -81,21 +94,25 @@
             "cmds" : [
                 {
                     "command" : "Get-WmiObject -Class Win32_Product | select Name, Vendor, Version, InstallDate",
+                    "type" : "ps",
                     "friendly" : "Win32 Apps",
                     "format" : "none"
                 },
                 {
                     "command" : "Get-AppxPackage | select Name, PackageFullName, Publisher, Version",
+                    "type" : "ps",
                     "friendly" : "Microsoft Store Apps",
                     "format" : "none"
                 },
                 {
                     "command" : "Get-ItemProperty HKLM:\\Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\* | select DisplayName, Publisher, InstallDate, DisplayVersion, HelpLink",
+                    "type" : "ps",
                     "friendly" : "Apps from Registry",
                     "format" : "none"
                 },
                 {
                     "command" : "Get-Process | select Name, Id, MainWindowTitle, Responding",
+                    "type" : "ps",
                     "friendly" : "Running Apps",
                     "format" : "none"
                 }
@@ -106,11 +123,13 @@
             "cmds" : [
                 {
                     "command" : "Get-Service | select DisplayName, Name, Status",
+                    "type" : "ps",
                     "friendly" : "Service Information",
                     "format" : "none"
                 },
                 {
                     "command" : "Get-Process",
+                    "type" : "ps",
                     "friendly" : "Process Information",
                     "format" : "none"
                 }
@@ -121,6 +140,7 @@
             "cmds" : [
                 {
                     "command" : "Get-MpComputerStatus",
+                    "type" : "ps",
                     "friendly" : "Defender Computer Status",
                     "format" : "none"
                 }

--- a/config.json
+++ b/config.json
@@ -65,9 +65,8 @@
                 },
                 {
                     "command" : "ipconfig /all",
-                    "type" : "ps",
-                    "friendly" : "IP Config",
-                    "format" : "none"
+                    "type" : "cmd",
+                    "friendly" : "IP Config"
                 },
                 {
                     "command" : "route print",


### PR DESCRIPTION
The dev branch has now completed the ability to create batch-based commands that run in a simple CMD terminal, rather than running a powershell terminal. A new variable within the "cmd" variables of the JSON file (type) will specify whether the command is to be run in PS or CMD.